### PR TITLE
Remove W3Schools and add better reference material on JavaScript

### DIFF
--- a/series/101/10_intro.md
+++ b/series/101/10_intro.md
@@ -42,7 +42,8 @@ Javascript guides
 
 * [Mozilla JavaScript guide](https://developer.mozilla.org/en/docs/Web/JavaScript/Guide)
 * [Codecademy](http://www.codecademy.com/courses/javascript-intro/0/1)
-* [Eloquent JavaScript](http://eloquentjavascript.net/)(e-Book)
+* [Eloquent JavaScript](http://eloquentjavascript.net/) (e-Book)
+* [Speaking JavaScript](http://speakingjs.com/) (e-Book)
 
 Pointers to different visualization approaches
 ---------------------------------


### PR DESCRIPTION
We know [W3Shools has been improving their content](http://www.w3fools.com/), but it's better to rely on reputable resources instead. :)
