### PR TITLE
Getting_Started: Change Tutorial Link

### DIFF
--- a/series/101/20_getting_started.md
+++ b/series/101/20_getting_started.md
@@ -26,7 +26,7 @@ npm help
 
 {% endhlblock %}
 
-If your machine is already set up, continue to the [tutorial]({{site.baseurl}}/101/modularity).
+If your machine is already set up, continue to the [tutorial](http://edu.biojs.net/101/modularity/).
 
 Otherwise, choose your operating system below to learn more: 
 


### PR DESCRIPTION
{{base_url}} was set to `0.0.0.101` hence, invalid link. Changed to http://edu.biojs.net/101/modularity/

Fixes https://github.com/biojs/edu/issues/48