### PR TITLE
redirect directly from start page and add slack chat link to 101 intro

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ layout: front
             <h1 class="cover-heading" style="font-size:60px">Learn BioJS</h1>
             <p class="lead">Beautiful. Interactive. Reusable.</p>
             <p class="lead">
-              <a href="#" class="btn btn-lg btn-default" id="getStarted"><img src="/img/logo.png" width="30px"> Get Started</a>
+              <a href="/101/intro" class="btn btn-lg btn-default" id="getStarted"><img src="/img/logo.png" width="30px"> Get Started</a>
             </p>
             <!--
             <p class="lead">

--- a/series/101/10_intro.md
+++ b/series/101/10_intro.md
@@ -18,15 +18,15 @@ Getting help
 
 Our education portal is work in progress. So if you encounter a logical inconsistency or just want to ask a question - don't hesitate to contact us.
 
-[![Gitter](https://badges.gitter.im/BioJS.png)](https://gitter.im/biojs/biojs){:target="_blank"}  &nbsp; &nbsp; &nbsp;   [![IRC](https://img.shields.io/badge/irc-%23biojs-yellow.svg)](https://kiwiirc.com/client/irc.freenode.net/biojs){:target="_blank"}
+[![Slack](https://img.shields.io/badge/slack-join%20chat-ff69b4.svg)](http://biojs-slackin.herokuapp.com/){:target="_blank"} &nbsp; &nbsp; &nbsp; [![Gitter](https://badges.gitter.im/BioJS.png)](https://gitter.im/biojs/biojs){:target="_blank"}  &nbsp; &nbsp; &nbsp;   [![IRC](https://img.shields.io/badge/irc-%23biojs-yellow.svg)](https://kiwiirc.com/client/irc.freenode.net/biojs){:target="_blank"}
 
-We also have a maintain a public [Github wiki][wiki] and have a [mailing list][groups].
+We also maintain a public [Github wiki][wiki] and have a [mailing list][groups].
 For technical queries (questions, suggestions, proposal or bug reports) [Github issues](https://github.com/biojs/biojs/issues) are preferred.
 
 If you find a type or want to help us to make this tutorial even better, you are invited to click on "Improve this page".
 
 [gitter]: https://gitter.im/biojs/biojs
-[groups]: https://groups.google.com/forum/#!forum/biojs
+[groups]: https://groups.google.com/forum/#!forum/biojavascript
 [issue]: https://github.com/biojs/biojs/issues
 [wiki]: https://github.com/biojs/biojs/wiki
 


### PR DESCRIPTION
minor fix of 
- redirecting directly from the start page once action button is clicked and
- updating community resources section