### PR TITLE
Fix #57: Dead links in snipinspector/outlook

### DIFF
--- a/series/snipspector/80_outlook.md
+++ b/series/snipspector/80_outlook.md
@@ -12,7 +12,7 @@ Did you really finish all previous tutorials? Wow.
 {% endalert %}
 
 
-### If you finished this tutorial successfully, you can create your own BioJS component and [publish it](05_publish_it.html)
+### If you finished this tutorial successfully, you can create your own BioJS component and [publish it]({{sitebaseurl}}/101/publish_it)
 
 {% hlblock help %}
 [Creating a pull request](https://help.github.com/articles/creating-a-pull-request).
@@ -28,4 +28,4 @@ Did you really finish all previous tutorials? Wow.
 It is not a shame to get inspiration and techniques from other popular packages.
 Just browse [our registry](http://biojs.io) for interesting or popular ones.
 
-### [Get involved in the awesome BioJS community](http://biojs.net/get_involved.html)
+### [Get involved in the awesome BioJS community](https://biojs.net/developers/)


### PR DESCRIPTION
This PR closes the issue #57 in which certain links under http://edu.biojs.net/snipspector/outlook/ redirected to 404 Not Found pages.